### PR TITLE
Swith to compatible xrd client for old dcache version at FNAL

### DIFF
--- a/src/python/WMCore/Storage/Backends/FNALImpl.py
+++ b/src/python/WMCore/Storage/Backends/FNALImpl.py
@@ -129,7 +129,7 @@ class FNALImpl(StageOutImpl):
             
             # always overwrite the output
 
-            result = "/usr/bin/xrdcp -d 0 -f "
+            result = "/usr/bin/xrdcp-old -d 0 -f "
             if options != None:
                 result += " %s " % options
             result += " %s " % sourcePFN


### PR DESCRIPTION
The newest version of xrdcp has problem staging out to versions
of dCache previous to 2.10. This is a workaround until the dCache
version is updated.